### PR TITLE
Fixed failing tests in test_common_utils and test_algorithms

### DIFF
--- a/mbrl/algorithms/mbpo.py
+++ b/mbrl/algorithms/mbpo.py
@@ -132,7 +132,8 @@ def train(
         color="green",
         dump_frequency=1,
     )
-    video_recorder = pytorch_sac.VideoRecorder(work_dir if cfg.save_video else None)
+    save_video = cfg.get("save_video", False)
+    video_recorder = pytorch_sac.VideoRecorder(work_dir if save_video else None)
 
     rng = np.random.default_rng(seed=cfg.seed)
     torch_generator = torch.Generator(device=cfg.device)

--- a/tests/core/test_common_utils.py
+++ b/tests/core/test_common_utils.py
@@ -42,7 +42,7 @@ def test_create_one_dim_tr_model():
         },
         "algorithm": {
             "learned_rewards": True,
-            "terget_is_delta": True,
+            "target_is_delta": True,
             "normalize": True,
         },
         "overrides": {},


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

Two tests were failing:

1. `FAILED tests/core/test_common_utils.py::test_create_one_dim_tr_model - omegaconf.errors.ConfigAttributeError: Missing key target_is_delta`
2. `FAILED tests/algorithms/test_algorithms.py::test_mbpo - omegaconf.errors.ConfigAttributeError: Missing key save_video`

## How Has This Been Tested (if it applies)

`python -m pytest tests/core` and `python -m pytest tests/algorithms`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](../../CONTRIBUTING.md) document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.

I didn't run MuJoCo tests.

<!--- In any case, don't hesitate to join and ask questions if you need on MBRL-Lib users Facebook group https://www.https://www.facebook.com/groups/mbrl.lib -->