### PR TITLE
Fixed the condition of the warning in ReplayBuffer.close_trajectory()

### DIFF
--- a/mbrl/util/replay_buffer.py
+++ b/mbrl/util/replay_buffer.py
@@ -268,15 +268,16 @@ class ReplayBuffer:
         new_trajectory = (self._start_last_trajectory, self.cur_idx)
         self.remove_overlapping_trajectories(new_trajectory)
         self.trajectory_indices.append(new_trajectory)
-        if self.cur_idx >= self.capacity:
-            self.cur_idx = 0
-        self._start_last_trajectory = self.cur_idx
 
         if self.cur_idx - self._start_last_trajectory > (len(self.obs) - self.capacity):
             warnings.warn(
                 "A trajectory was saved with length longer than expected. "
                 "Unexpected behavior might occur."
             )
+
+        if self.cur_idx >= self.capacity:
+            self.cur_idx = 0
+        self._start_last_trajectory = self.cur_idx
 
     def add(
         self,

--- a/mbrl/util/replay_buffer.py
+++ b/mbrl/util/replay_buffer.py
@@ -257,7 +257,7 @@ class ReplayBuffer:
             warnings.warn(
                 "The replay buffer was filled before current trajectory finished. "
                 "The history of the current partial trajectory will be discarded. "
-                "Make sure you set `max_trajectory_length` to the appropriate value"
+                "Make sure you set `max_trajectory_length` to the appropriate value "
                 "for your problem."
             )
             self._start_last_trajectory = 0


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
This fixes a bug which caused the warning in ReplayBuffer.close_trajectory() to never be triggered,  even in cases where it should apply. Furthermore, it adds a missing space in the warning text in ReplayBuffer._trajectory_bookkeeping().

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The warning in  ReplayBuffer.close_trajectory() was never triggered. This was due to the fact that `self._start_last_trajectory = self.cur_idx` was set directly before `self.cur_idx - self._start_last_trajectory > (len(self.obs) - self.capacity)` is tested. Due to the previous assignment, the left hand side of the inequality was always zero, which caused the condition to be false in all cases.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
With the modifications the following code triggers the warning since it attempts to add a trajectory of length 2 to replay buffer with max_trajectory_length 1. Without the modifications the warning is not triggered.
```
import numpy as np
from mbrl.util import ReplayBuffer

replay = ReplayBuffer(2, (1,), (1,), max_trajectory_length=1)
dummy = np.array([1])

replay.add(dummy, dummy, dummy, 1, False)
replay.add(dummy, dummy, dummy, 1, False)
replay.close_trajectory()
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](../../CONTRIBUTING.md) document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on MBRL-Lib users Facebook group https://www.https://www.facebook.com/groups/mbrl.lib -->