### PR TITLE
Fixed a bug where SequenceTransitionIterator.__len__() ignores max_batches_per_loop

### DIFF
--- a/mbrl/util/replay_buffer.py
+++ b/mbrl/util/replay_buffer.py
@@ -276,6 +276,12 @@ class SequenceTransitionIterator(BootstrapIterator):
             raise StopIteration
         return super().__next__()
 
+    def __len__(self):
+        if self._max_batches_per_loop is not None:
+            return min(super().__len__(), self._max_batches_per_loop)
+        else:
+            return super().__len__()
+
     def __getitem__(self, item):
         start_indices = self._valid_starts[item].repeat(self._sequence_length)
         increment_array = np.tile(np.arange(self._sequence_length), len(item))

--- a/tests/core/test_replay_buffer.py
+++ b/tests/core/test_replay_buffer.py
@@ -521,3 +521,4 @@ def test_sequence_iterator_max_batches_per_loop():
         for _ in iterator:
             cnt += 1
         assert cnt == max_batches
+        assert len(iterator) == max_batches


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

In the current version `SequenceTransitionIterator` does not override the `__len__()` function of `TransitionIterator`. Therefore, the `max_batches_per_loop` parameter is ignored during the calculation of the length of the iterator. This causes the number of batches returned by the iterator to be larger than `len(iterator)` if `max_batches_per_loop` is used. 

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

I added a test for `len(iterator)` to `test_sequence_iterator_max_batches_per_loop()` in tests/core/test_replay_buffer.py.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](../../CONTRIBUTING.md) document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on MBRL-Lib users Facebook group https://www.https://www.facebook.com/groups/mbrl.lib -->