### PR TITLE
Fixed a bug where a default argument to get_sequence_buffer_iterator causes a crash and added an assertion for clarity

### DIFF
--- a/mbrl/util/common.py
+++ b/mbrl/util/common.py
@@ -278,6 +278,12 @@ def get_sequence_buffer_iterator(
         and validation iterators, respectively.
     """
 
+    assert replay_buffer.stores_trajectories, (
+        "The passed replay buffer does not store trajectory information. "
+        "Make sure that the replay buffer is created with the max_trajectory_length "
+        "parameter set."
+    )
+
     transitions = replay_buffer.get_all()
     num_trajectories = len(replay_buffer.trajectory_indices)
     val_size = int(num_trajectories * val_ratio)

--- a/mbrl/util/common.py
+++ b/mbrl/util/common.py
@@ -250,7 +250,7 @@ def get_sequence_buffer_iterator(
     batch_size: int,
     val_ratio: float,
     sequence_length: int,
-    ensemble_size: Optional[int] = None,
+    ensemble_size: int = 1,
     shuffle_each_epoch: bool = True,
     max_batches_per_loop_train: Optional[int] = None,
     max_batches_per_loop_val: Optional[int] = None,


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The current implementation of `get_sequence_buffer_iterator()` crashes with a the error `TypeError: '>' not supported between instances of 'NoneType' and 'int'` if the default value (`None`) is passed for the `ensemble_size` parameter. I changed the default value to 1 and changed the type of the parameter from `Optional[int]` to `int`. This fixes the problem and is also in line with the `ensemble_size` parameter of `get_basic_buffer_iterators()`.

Furthermore, I added an assertion to `get_sequence_buffer_iterator()` that ensures that the replay buffer passed to the function stores trajectory information (`replay_buffer.stores_trajectories` is true). Without this assertion, the function just crashes with the error `TypeError: object of type 'NoneType' has no len()` if this is not the case. The assertion should make the problem more clear and easier to debug for users.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

```
from mbrl.util.replay_buffer import ReplayBuffer
from mbrl.util.common import get_sequence_buffer_iterator

replay_buffer = ReplayBuffer(10, (1,), (1,), max_trajectory_length=1)
get_sequence_buffer_iterator(replay_buffer, 1, 0.0, 1)
```
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](../../CONTRIBUTING.md) document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on MBRL-Lib users Facebook group https://www.https://www.facebook.com/groups/mbrl.lib -->