### PR TITLE
Fixed some type hints of ReplayBuffer

### DIFF
--- a/mbrl/util/common.py
+++ b/mbrl/util/common.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import pathlib
-from typing import Callable, Dict, List, Optional, Tuple, Union, Iterable
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import gym.wrappers
 import hydra
@@ -124,8 +124,8 @@ def load_hydra_cfg(results_dir: Union[str, pathlib.Path]) -> omegaconf.DictConfi
 
 def create_replay_buffer(
     cfg: omegaconf.DictConfig,
-    obs_shape: Iterable[int],
-    act_shape: Iterable[int],
+    obs_shape: Sequence[int],
+    act_shape: Sequence[int],
     load_dir: Optional[Union[str, pathlib.Path]] = None,
     collect_trajectories: bool = False,
     rng: Optional[np.random.Generator] = None,
@@ -148,8 +148,8 @@ def create_replay_buffer(
 
     Args:
         cfg (omegaconf.DictConfig): the configuration to use.
-        obs_shape (Iterable of ints): the shape of observation arrays.
-        act_shape (Iterable of ints): the shape of action arrays.
+        obs_shape (Sequence of ints): the shape of observation arrays.
+        act_shape (Sequence of ints): the shape of action arrays.
         load_dir (optional str or pathlib.Path): if provided, the function will attempt to
             populate the buffers from "load_dir/replay_buffer.npz".
         collect_trajectories (bool, optional): if ``True`` sets the replay buffers to collect

--- a/mbrl/util/common.py
+++ b/mbrl/util/common.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import pathlib
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union, Iterable
 
 import gym.wrappers
 import hydra
@@ -124,8 +124,8 @@ def load_hydra_cfg(results_dir: Union[str, pathlib.Path]) -> omegaconf.DictConfi
 
 def create_replay_buffer(
     cfg: omegaconf.DictConfig,
-    obs_shape: Tuple[int],
-    act_shape: Tuple[int],
+    obs_shape: Iterable[int],
+    act_shape: Iterable[int],
     load_dir: Optional[Union[str, pathlib.Path]] = None,
     collect_trajectories: bool = False,
     rng: Optional[np.random.Generator] = None,
@@ -148,8 +148,8 @@ def create_replay_buffer(
 
     Args:
         cfg (omegaconf.DictConfig): the configuration to use.
-        obs_shape (tuple of ints): the shape of observation arrays.
-        act_shape (tuple of ints): the shape of action arrays.
+        obs_shape (Iterable of ints): the shape of observation arrays.
+        act_shape (Iterable of ints): the shape of action arrays.
         load_dir (optional str or pathlib.Path): if provided, the function will attempt to
             populate the buffers from "load_dir/replay_buffer.npz".
         collect_trajectories (bool, optional): if ``True`` sets the replay buffers to collect

--- a/mbrl/util/replay_buffer.py
+++ b/mbrl/util/replay_buffer.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 import pathlib
 import warnings
-from typing import List, Optional, Sequence, Sized, Tuple, Union, Iterable
+from typing import List, Optional, Sequence, Sized, Tuple, Union
 
 import numpy as np
 
@@ -173,8 +173,8 @@ class ReplayBuffer:
     Args:
         capacity (int): the maximum number of transitions that the buffer can store.
             When the capacity is reached, the contents are overwritten in FIFO fashion.
-        obs_shape (Iterable of ints): the shape of the observations to store.
-        action_shape (Iterable of ints): the shape of the actions to store.
+        obs_shape (Sequence of ints): the shape of the observations to store.
+        action_shape (Sequence of ints): the shape of the actions to store.
         obs_type (type): the data type of the observations (defaults to np.float32).
         action_type (type): the data type of the actions (defaults to np.float32).
         rng (np.random.Generator, optional): a random number generator when sampling
@@ -193,8 +193,8 @@ class ReplayBuffer:
     def __init__(
         self,
         capacity: int,
-        obs_shape: Iterable[int],
-        action_shape: Iterable[int],
+        obs_shape: Sequence[int],
+        action_shape: Sequence[int],
         obs_type=np.float32,
         action_type=np.float32,
         rng: Optional[np.random.Generator] = None,

--- a/mbrl/util/replay_buffer.py
+++ b/mbrl/util/replay_buffer.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 import pathlib
 import warnings
-from typing import List, Optional, Sequence, Sized, Tuple, Union
+from typing import List, Optional, Sequence, Sized, Tuple, Union, Iterable
 
 import numpy as np
 
@@ -173,8 +173,8 @@ class ReplayBuffer:
     Args:
         capacity (int): the maximum number of transitions that the buffer can store.
             When the capacity is reached, the contents are overwritten in FIFO fashion.
-        obs_shape (tuple of ints): the shape of the observations to store.
-        action_shape (tuple of ints): the shape of the actions to store.
+        obs_shape (Iterable of ints): the shape of the observations to store.
+        action_shape (Iterable of ints): the shape of the actions to store.
         obs_type (type): the data type of the observations (defaults to np.float32).
         action_type (type): the data type of the actions (defaults to np.float32).
         rng (np.random.Generator, optional): a random number generator when sampling
@@ -193,8 +193,8 @@ class ReplayBuffer:
     def __init__(
         self,
         capacity: int,
-        obs_shape: Tuple[int],
-        action_shape: Tuple[int],
+        obs_shape: Iterable[int],
+        action_shape: Iterable[int],
         obs_type=np.float32,
         action_type=np.float32,
         rng: Optional[np.random.Generator] = None,

--- a/mbrl/util/replay_buffer.py
+++ b/mbrl/util/replay_buffer.py
@@ -223,7 +223,7 @@ class ReplayBuffer:
         self._start_last_trajectory = 0
 
     @property
-    def stores_trajectories(self):
+    def stores_trajectories(self) -> bool:
         return self.trajectory_indices is not None
 
     @staticmethod
@@ -308,7 +308,7 @@ class ReplayBuffer:
             self.cur_idx = (self.cur_idx + 1) % self.capacity
             self.num_stored = min(self.num_stored + 1, self.capacity)
 
-    def sample(self, batch_size: int) -> Sized:
+    def sample(self, batch_size: int) -> TransitionBatch:
         """Samples a batch of transitions from the replay buffer.
 
         Args:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The type hints for `obs_shape` and `action_shape` (`Tuple[int]`) only allowed tuples with one element. Hence, the type checker complained when using `ReplayBuffer` with multi-dimensional observations / actions, even though it works fine (in fact I have been using `ReplayBuffer` with image observations for quite some time now). Instead of changing the type hints to `Tuple[int, ...]`, I changed them to `Iterable[int]` since it works just as fine and make the class easier to use (it also allows passing the shape e.g. as list instead of tuple).

Furthermore, I changed the type of the return value of `sample()` since it was a little unspecific. The function always returns a `TransitionBatch`. Because the type hint was `Sized`, the type checker complained if e.g. `replay_buffer.sample(1).obs` is executed.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
```
import numpy as np
from omegaconf import DictConfig

from mbrl.util.common import create_replay_buffer

cfg = DictConfig({"overrides": {"num_steps": 42}})
obs_shape = [1, 2, 3]
action_shape = [1, 2]
replay = create_replay_buffer(cfg, obs_shape, action_shape)

obs = np.random.random(obs_shape).astype(np.float32)
action = np.random.random(action_shape).astype(np.float32)
next_obs = np.random.random(obs_shape).astype(np.float32)
replay.add(obs, action, next_obs, 0.0, False)
batch_sampled = replay.sample(1)
assert np.all(batch_sampled.obs[0] == obs)
assert np.all(batch_sampled.act[0] == action)
assert np.all(batch_sampled.next_obs[0] == next_obs)
```

Running mypy on the program above, yields no type errors.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](../../CONTRIBUTING.md) document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on MBRL-Lib users Facebook group https://www.https://www.facebook.com/groups/mbrl.lib -->