### PR TITLE
Fixed wrong absolute value parenthesis in Hopper's termination function.

### DIFF
--- a/mbrl/env/termination_fns.py
+++ b/mbrl/env/termination_fns.py
@@ -16,7 +16,7 @@ def hopper(act: torch.Tensor, next_obs: torch.Tensor) -> torch.Tensor:
     angle = next_obs[:, 1]
     not_done = (
         torch.isfinite(next_obs).all(-1)
-        * (next_obs[:, 1:] < 100).abs().all(-1)
+        * (next_obs[:, 1:].abs() < 100).all(-1)
         * (height > 0.7)
         * (angle.abs() < 0.2)
     )


### PR DESCRIPTION
## Types of changes
The termination function for Hopper had a bug that was causing crashes when running on CPU. See explanation in https://github.com/facebookresearch/mbrl-lib/issues/113#issuecomment-889203870.

Closes #113 

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](../../CONTRIBUTING.md) document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on MBRL-Lib users Facebook group https://www.https://www.facebook.com/groups/mbrl.lib -->