### PR TITLE
[Bug-fix] Made truncated_normal_ completely in-place

### DIFF
--- a/mbrl/util/math.py
+++ b/mbrl/util/math.py
@@ -66,7 +66,9 @@ def gaussian_nll(
 
 # inplace truncated normal function for pytorch.
 # credit to https://github.com/Xingyu-Lin/mbpo_pytorch/blob/main/model.py#L64
-def truncated_normal_(tensor: torch.Tensor, mean: float = 0, std: float = 1):
+def truncated_normal_(
+    tensor: torch.Tensor, mean: float = 0, std: float = 1
+) -> torch.Tensor:
     """Samples from a truncated normal distribution in-place.
 
     Args:
@@ -81,14 +83,11 @@ def truncated_normal_(tensor: torch.Tensor, mean: float = 0, std: float = 1):
     torch.nn.init.normal_(tensor, mean=mean, std=std)
     while True:
         cond = torch.logical_or(tensor < mean - 2 * std, tensor > mean + 2 * std)
-        if not torch.sum(cond):
+        bound_violations = torch.sum(cond).item()
+        if bound_violations == 0:
             break
-        tensor = torch.where(
-            cond,
-            torch.nn.init.normal_(
-                torch.ones(tensor.shape, device=tensor.device), mean=mean, std=std
-            ),
-            tensor,
+        tensor[cond] = torch.normal(
+            mean, std, size=(bound_violations,), device=tensor.device
         )
     return tensor
 

--- a/tests/core/test_common_utils.py
+++ b/tests/core/test_common_utils.py
@@ -372,3 +372,10 @@ def test_bootstrap_rb_sample_obs3d():
         for i in range(ensemble_size):
             for j in range(i + 1, ensemble_size):
                 assert not np.array_equal(batch.obs[i], batch.obs[j])
+
+
+def test_truncated_normal():
+    t_original = torch.empty((100, 2))
+    t_new = mbrl.util.math.truncated_normal_(t_original)
+    assert t_original is t_new
+    assert (t_original > -2).all().item() and (t_original < 2).all().item()


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

The current implementation of `mbrl.util.math.truncated_normal_()` is not (entirely) in-place. This problem can be seen with the following code snippet.
```
import torch

import mbrl.util.math

t_original = torch.empty(1000)
t_new = mbrl.util.math.truncated_normal_(t_original)

print((t_original == t_new).all().item())
print(((t_original <= 2.0).all() and (t_original >= -2.0).all()).item())
```
With the current implementation, both outputs are `False`. If the implementation was in-place, both outputs should be `True`. The problem is that `torch.where()`, used in `truncated_normal_()`, is not an in-place operation. As a result, `t_original` contains values sampled from a regular Gaussian, while `t_new` contains values sampled from the truncated Gaussian.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
```
import torch
import matplotlib.pyplot as plt

import mbrl.util.math

t_original = torch.empty(5000000)
t_new = mbrl.util.math.truncated_normal_(t_original)
assert (t_original == t_new).all().item()

plt.hist(t_original.cpu().numpy(), 100)
plt.show()
```
After the changes, the code snippet above results in the following histogram, which shows that the values are sampled from a Gaussian truncated to [-2, 2].
![truncated_normal_results](https://user-images.githubusercontent.com/33448112/148550375-1941e416-9853-437e-b16e-bc9a366cd75b.png)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](../../CONTRIBUTING.md) document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on MBRL-Lib users Facebook group https://www.https://www.facebook.com/groups/mbrl.lib -->