### PR TITLE
Fix Hydra warning by sticking to OmegaConf 2.0.x

### DIFF
--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,3 +1,4 @@
+omegaconf>=2.0,<2.1
 hydra-core==1.0.3
 termcolor>=1.1.0
 tensorboard>=2.4.0


### PR DESCRIPTION
## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

The deprecation of OmegaConf.is_none() in OmegaConf 2.1 causes a warning
with Hydra 1.0.x. The fix consists in using an older version of
OmegaConf.

## How Has This Been Tested (if it applies)

python -m pytest tests/core
python -m pytest tests/algorithms

## Checklist

- [X] The documentation is up-to-date with the changes I made.
- [X] I have read the [**CONTRIBUTING**](../../CONTRIBUTING.md) document and completed the CLA (see **CONTRIBUTING**).
- [X] All tests passed, and additional code has been covered with new tests.