### PR TITLE
Make `create_one_dim_tr_model` recognize subclasses of `BasicEnsemble`

### DIFF
--- a/mbrl/util/common.py
+++ b/mbrl/util/common.py
@@ -77,7 +77,7 @@ def create_one_dim_tr_model(
     # This first part takes care of the case where model is BasicEnsemble and in/out sizes
     # are handled by member_cfg
     model_cfg = cfg.dynamics_model
-    if model_cfg._target_ == "mbrl.models.BasicEnsemble":
+    if issubclass(hydra.utils._locate(model_cfg._target_), mbrl.models.BasicEnsemble):
         model_cfg = model_cfg.member_cfg
     if model_cfg.get("in_size", None) is None:
         model_cfg.in_size = obs_shape[0] + (act_shape[0] if act_shape else 1)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

In the current implementation, `create_one_dim_tr_model` identifies the `BasicEnsemble` class through the attribute `_target_` of `cfg.dynamics_model`, and this process relies entirely on string comparison. This prevents developers from inheriting the `BasicEnsemble` class to achieve the specific functions they need. We should judge whether the class corresponding to `_target_` is a subclass of `BasicEnsemble` rather than just compare the string. The corresponding issue is #182.



## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
In `tests/core/test_common_utils.py`, add class `CustomEnsemble`  inheriting `BasicEnsemble` and and create it using `create_one_dim_tr_model`. Check the correction of `dynamics_model.model.in_size` and `dynamics_model.model.out_size` then.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the [**CONTRIBUTING**](../../CONTRIBUTING.md) document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.

<!--- In any case, don't hesitate to join and ask questions if you need on MBRL-Lib users Facebook group https://www.https://www.facebook.com/groups/mbrl.lib -->